### PR TITLE
add topologySpreadConstraints

### DIFF
--- a/charts/k8s-sizing-webhook/templates/deployment.yaml
+++ b/charts/k8s-sizing-webhook/templates/deployment.yaml
@@ -79,6 +79,21 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints.enable }}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: {{ .Values.topologySpreadConstraints.policy | quote }}
+        labelSelector:
+          matchLabels:
+            {{- include "k8s-sizing-webhook.selectorLabels" . | nindent 12 }}
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: {{ .Values.topologySpreadConstraints.policy | quote }}
+        labelSelector:
+          matchLabels:
+            {{- include "k8s-sizing-webhook.selectorLabels" . | nindent 12 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/k8s-sizing-webhook/values.yaml
+++ b/charts/k8s-sizing-webhook/values.yaml
@@ -50,6 +50,10 @@ podDisruptionBudget:
   create: true
   minAvailable: 1
 
+topologySpreadConstraints:
+  enable: true
+  policy: ScheduleAnyway
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
To make the deployment as resilient as possible, we distribute it by default. I opted against "DoNotSchedule" as we want to have the pods as fast as possible and also provide stable operations on a single node cluster.